### PR TITLE
Add PDF-based network planning UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # tests
+
+Esta aplicación web permite cargar planos en PDF y colocar elementos de red
+(routers, switches, puntos de acceso, cámaras, etc.) sobre el plano. También
+se pueden trazar cables de distintos tipos entre los dispositivos.
+
+Para usarla simplemente abre `index.html` en tu navegador, carga un PDF desde
+el botón de selección y arrastra los iconos al lugar deseado.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diseño de Red</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+</head>
+<body>
+  <h1>Aplicación de planos de red</h1>
+  <input type="file" id="pdfUploader" accept="application/pdf">
+
+  <div id="palette">
+    <button onclick="addIcon('router')">Router</button>
+    <button onclick="addIcon('switch')">Switch</button>
+    <button onclick="addIcon('ap')">AP</button>
+    <button onclick="addIcon('camera')">Cámara</button>
+    <button onclick="addIcon('ctrl')">Controladora</button>
+  </div>
+
+  <div>
+    <label for="cableType">Tipo de cable:</label>
+    <select id="cableType">
+      <option value="utp">UTP</option>
+      <option value="fibra">Fibra</option>
+      <option value="coax">Coaxial</option>
+    </select>
+  </div>
+
+  <div id="workspace">
+    <canvas id="pdfCanvas"></canvas>
+    <svg id="linkLayer"></svg>
+    <div id="overlay"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,84 @@
+const pdfCanvas = document.getElementById('pdfCanvas');
+const ctx = pdfCanvas.getContext('2d');
+const overlay = document.getElementById('overlay');
+const linkLayer = document.getElementById('linkLayer');
+let startIcon = null;
+
+// Cargar PDF en el canvas
+pdfUploader.addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const data = await file.arrayBuffer();
+  const pdf = await pdfjsLib.getDocument({ data }).promise;
+  const page = await pdf.getPage(1);
+  const vp = page.getViewport({ scale: 1 });
+  pdfCanvas.width = vp.width;
+  pdfCanvas.height = vp.height;
+  await page.render({ canvasContext: ctx, viewport: vp }).promise;
+});
+
+function addIcon(type) {
+  const img = document.createElement('img');
+  img.className = 'icon';
+  img.src = getIcon(type);
+  img.style.left = '10px';
+  img.style.top = '10px';
+  img.draggable = true;
+  overlay.appendChild(img);
+  img.addEventListener('dragstart', dragStart);
+  img.addEventListener('dragend', dragEnd);
+  img.addEventListener('click', iconClick);
+}
+
+function getIcon(type) {
+  switch (type) {
+    case 'router':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="30" fill="lightblue" stroke="black"/></svg>';
+    case 'switch':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect x="8" y="20" width="48" height="24" fill="orange" stroke="black"/></svg>';
+    case 'ap':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><polygon points="32,4 60,60 4,60" fill="lightgreen" stroke="black"/></svg>';
+    case 'camera':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="gray" stroke="black"/></svg>';
+    case 'ctrl':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect x="16" y="16" width="32" height="32" fill="pink" stroke="black"/></svg>';
+    default:
+      return '';
+  }
+}
+
+function dragStart(e) {
+  e.dataTransfer.setData('text/plain', '');
+}
+
+function dragEnd(e) {
+  const rect = overlay.getBoundingClientRect();
+  this.style.left = e.clientX - rect.left - 16 + 'px';
+  this.style.top = e.clientY - rect.top - 16 + 'px';
+}
+
+function iconClick(e) {
+  if (startIcon === null) {
+    startIcon = this;
+    this.classList.add('selected');
+  } else if (startIcon === this) {
+    startIcon.classList.remove('selected');
+    startIcon = null;
+  } else {
+    connect(startIcon, this);
+    startIcon.classList.remove('selected');
+    startIcon = null;
+  }
+}
+
+function connect(a, b) {
+  const cable = document.getElementById('cableType').value;
+  const colors = { utp: 'blue', fibra: 'red', coax: 'green' };
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  line.setAttribute('x1', parseInt(a.style.left) + 16);
+  line.setAttribute('y1', parseInt(a.style.top) + 16);
+  line.setAttribute('x2', parseInt(b.style.left) + 16);
+  line.setAttribute('y2', parseInt(b.style.top) + 16);
+  line.setAttribute('stroke', colors[cable] || 'black');
+  linkLayer.appendChild(line);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 2rem;
+}
+
+h1 {
+  color: #333;
+}
+
+#palette button {
+  margin-right: 0.5rem;
+}
+
+#workspace {
+  position: relative;
+  border: 1px solid #ccc;
+  width: 100%;
+  max-width: 800px;
+  height: 600px;
+  margin-top: 1rem;
+}
+
+#pdfCanvas {
+  width: 100%;
+  height: 100%;
+}
+
+#overlay,
+#linkLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.icon {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  cursor: move;
+}
+
+.selected {
+  outline: 2px dashed red;
+}
+
+svg line {
+  stroke-width: 2;
+}


### PR DESCRIPTION
## Summary
- allow uploading PDF plans
- drag icons for common network devices onto the plan
- draw colored lines for UTP, fiber or coax cables
- document how to use the app in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d1f1a87788332a6df469eece7deb8