### PR TITLE
Improve network planner UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # tests
+
+Esta aplicación web permite cargar planos en PDF y colocar elementos de red
+(routers, switches, puntos de acceso, cámaras, etc.) sobre el plano. También
+se pueden trazar cables de distintos tipos entre los dispositivos.
+
+Abre `index.html` en tu navegador. Desde la barra superior podrás cargar el PDF que hará de plano y elegir el modo de trabajo:
+
+- **Añadir**: permite insertar dispositivos desde la paleta y conectar dos de ellos pulsando primero uno y luego otro.
+- **Seleccionar**: habilita el movimiento de los dispositivos y, al pulsar sobre uno, podrás indicar su nombre, dirección IP, MAC y número de inventario.
+
+Los cables se dibujan con colores según el tipo elegido (UTP, fibra o coaxial).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diseño de Red</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+</head>
+<body>
+  <div id="toolbar">
+    <input type="file" id="pdfUploader" accept="application/pdf">
+    <select id="mode">
+      <option value="add">Añadir</option>
+      <option value="select">Seleccionar</option>
+    </select>
+    <div id="palette">
+      <button data-type="router">Router</button>
+      <button data-type="switch">Switch</button>
+      <button data-type="ap">AP</button>
+      <button data-type="camera">Cámara</button>
+      <button data-type="ctrl">Controladora</button>
+    </div>
+    <label for="cableType">Cable:</label>
+    <select id="cableType">
+      <option value="utp">UTP</option>
+      <option value="fibra">Fibra</option>
+      <option value="coax">Coaxial</option>
+    </select>
+  </div>
+
+  <div id="workspace">
+    <canvas id="pdfCanvas"></canvas>
+    <svg id="linkLayer"></svg>
+    <div id="overlay"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,123 @@
+const pdfCanvas = document.getElementById('pdfCanvas');
+const ctx = pdfCanvas.getContext('2d');
+const overlay = document.getElementById('overlay');
+const linkLayer = document.getElementById('linkLayer');
+const modeSelect = document.getElementById('mode');
+const pdfUploader = document.getElementById('pdfUploader');
+document.querySelectorAll('#palette button').forEach(btn => {
+  btn.addEventListener('click', () => addIcon(btn.dataset.type));
+});
+let mode = modeSelect.value;
+let startIcon = null;
+
+modeSelect.addEventListener('change', () => {
+  mode = modeSelect.value;
+});
+
+// Cargar PDF en el canvas
+pdfUploader.addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const data = await file.arrayBuffer();
+  const pdf = await pdfjsLib.getDocument({ data }).promise;
+  const page = await pdf.getPage(1);
+  const vp = page.getViewport({ scale: 1 });
+  pdfCanvas.width = vp.width;
+  pdfCanvas.height = vp.height;
+  await page.render({ canvasContext: ctx, viewport: vp }).promise;
+});
+
+function addIcon(type) {
+  if (mode !== 'add') return;
+  const dev = document.createElement('div');
+  dev.className = 'device';
+  dev.style.left = '10px';
+  dev.style.top = '10px';
+  dev.draggable = true;
+
+  const img = document.createElement('img');
+  img.className = 'icon';
+  img.src = getIcon(type);
+  dev.appendChild(img);
+
+  const label = document.createElement('div');
+  label.className = 'label';
+  dev.appendChild(label);
+
+  overlay.appendChild(dev);
+  dev.addEventListener('dragstart', dragStart);
+  dev.addEventListener('dragend', dragEnd);
+  dev.addEventListener('click', iconClick);
+}
+
+function getIcon(type) {
+  switch (type) {
+    case 'router':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="30" fill="lightblue" stroke="black"/></svg>';
+    case 'switch':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect x="8" y="20" width="48" height="24" fill="orange" stroke="black"/></svg>';
+    case 'ap':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><polygon points="32,4 60,60 4,60" fill="lightgreen" stroke="black"/></svg>';
+    case 'camera':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="20" fill="gray" stroke="black"/></svg>';
+    case 'ctrl':
+      return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect x="16" y="16" width="32" height="32" fill="pink" stroke="black"/></svg>';
+    default:
+      return '';
+  }
+}
+
+function dragStart(e) {
+  if (mode !== 'select') {
+    e.preventDefault();
+    return;
+  }
+  e.dataTransfer.setData('text/plain', '');
+}
+
+function dragEnd(e) {
+  if (mode !== 'select') return;
+  const rect = overlay.getBoundingClientRect();
+  this.style.left = e.clientX - rect.left - 16 + 'px';
+  this.style.top = e.clientY - rect.top - 16 + 'px';
+}
+
+function iconClick(e) {
+  if (mode === 'select') {
+    const name = prompt('Nombre', this.dataset.name || '');
+    if (name !== null) {
+      this.dataset.name = name;
+      this.querySelector('.label').textContent = name;
+    }
+    const ip = prompt('IP', this.dataset.ip || '');
+    if (ip !== null) this.dataset.ip = ip;
+    const mac = prompt('MAC', this.dataset.mac || '');
+    if (mac !== null) this.dataset.mac = mac;
+    const inv = prompt('Inventario', this.dataset.inv || '');
+    if (inv !== null) this.dataset.inv = inv;
+  } else {
+    if (startIcon === null) {
+      startIcon = this;
+      this.classList.add('selected');
+    } else if (startIcon === this) {
+      startIcon.classList.remove('selected');
+      startIcon = null;
+    } else {
+      connect(startIcon, this);
+      startIcon.classList.remove('selected');
+      startIcon = null;
+    }
+  }
+}
+
+function connect(a, b) {
+  const cable = document.getElementById('cableType').value;
+  const colors = { utp: 'blue', fibra: 'red', coax: 'green' };
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  line.setAttribute('x1', parseInt(a.style.left) + a.offsetWidth / 2);
+  line.setAttribute('y1', parseInt(a.style.top) + a.offsetHeight / 2);
+  line.setAttribute('x2', parseInt(b.style.left) + b.offsetWidth / 2);
+  line.setAttribute('y2', parseInt(b.style.top) + b.offsetHeight / 2);
+  line.setAttribute('stroke', colors[cable] || 'black');
+  linkLayer.appendChild(line);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,78 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: Arial, sans-serif;
+  background: #fafafa;
+}
+
+#toolbar {
+  display: flex;
+  align-items: center;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+}
+
+#toolbar input,
+#toolbar select,
+#palette button {
+  margin-right: 1rem;
+}
+
+#palette button {
+  background: #555;
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#workspace {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+#pdfCanvas {
+  width: 100%;
+  height: 100%;
+}
+
+#overlay,
+#linkLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.device {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.label {
+  position: absolute;
+  top: 34px;
+  left: 0;
+  font-size: 0.7rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 2px;
+  pointer-events: none;
+}
+
+.selected {
+  outline: 2px dashed red;
+}
+
+svg line {
+  stroke-width: 2;
+}


### PR DESCRIPTION
## Summary
- redesign page with a dark toolbar and fullscreen workspace
- add mode selector for adding or selecting devices
- clicking a device in select mode lets you enter name, IP, MAC and inventory
- allow dragging only in select mode
- update README with new instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d1f1a87788332a6df469eece7deb8